### PR TITLE
Fixed secret to be saved to machine

### DIFF
--- a/Umbraco.AuthTokens/Data/UmbracoAuthTokenSecret.cs
+++ b/Umbraco.AuthTokens/Data/UmbracoAuthTokenSecret.cs
@@ -16,7 +16,7 @@ namespace UmbracoAuthTokens.Data
         /// <param name="secret">Secret string to set</param>
         public static void SetSecret(string secret)
         {
-            Environment.SetEnvironmentVariable(SecretEnvVariable, secret);
+            Environment.SetEnvironmentVariable(SecretEnvVariable, secret,EnvironmentVariableTarget.Machine);
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace UmbracoAuthTokens.Data
         /// <returns>Returns the string secret</returns>
         public static string GetSecret()
         {
-            var secret = Environment.GetEnvironmentVariable(SecretEnvVariable);
+            var secret = Environment.GetEnvironmentVariable(SecretEnvVariable, EnvironmentVariableTarget.Machine);
 
             //If it does not exist or is null/empty then we set a new one
             if (string.IsNullOrEmpty(secret))


### PR DESCRIPTION
We noticed that the Secret was being saved to the process's environment variables, which was causing periodic 401's as our IIS app-pool was cooled/refreshed. The method summary suggests you were intending to use the machine set of variables. 